### PR TITLE
Add biophysics to DFTB+ entry

### DIFF
--- a/app/applications/applications-data.ts
+++ b/app/applications/applications-data.ts
@@ -55,6 +55,7 @@ export const applications: Application[] = [
     categories: [applicationCategories.COMPUTATIONAL_CHEMISTRY,
     applicationCategories.MATERIALS_SCIENCE,
     applicationCategories.PHYSICS_SIMULATION,
+    applicationCategories.BIOPHYSICS,
     applicationCategories.HIGH_PERFORMANCE_COMPUTING],
   },
   {


### PR DESCRIPTION
As the DFTB mio parameters were particularly for computational biochemistry and DFTB+ has implicit solvent models.